### PR TITLE
API body Google Forms

### DIFF
--- a/python/tmp_api/api_forms_body.py
+++ b/python/tmp_api/api_forms_body.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+import pandas as pd
+from apiclient import discovery
+from httplib2 import Http
+from oauth2client import client, file, tools
+
+SCOPES = "https://www.googleapis.com/auth/forms.body.readonly"
+DISCOVERY_DOC = "https://forms.googleapis.com/$discovery/rest?version=v1"
+
+store = file.Storage('token.json')
+creds = store.get()
+if not creds or creds.invalid:
+    flow = client.flow_from_clientsecrets('client_secrets.json', SCOPES)
+    creds = tools.run_flow(flow, store)
+service = discovery.build('forms', 'v1', http=creds.authorize(
+    Http()), discoveryServiceUrl=DISCOVERY_DOC, static_discovery=False)
+
+# Prints the title of the sample form:
+form_id = '1kOotaOJQlcwmlj46cH3mfDrz0mAHAFqBodSO-Kho2Pc'
+result = service.forms().get(formId=form_id).execute()
+print(result)
+
+df = pd.DataFrame.from_dict(result)
+df.to_csv('api_forms_body.csv')


### PR DESCRIPTION
Con esta llamada a la API, a parte de tener las respuestas, tenemos el cuerpo de las preguntas.
En este caso, ya está con el gitignore, para que no se vean las credenciales.